### PR TITLE
fix: replace api.paperlib.app with Semantic Scholar Graph API

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,20 +52,21 @@ class PaperlibCitationCountExtension extends PLExtension {
       },
     });
 
+    const SS_BASE = "https://api.semanticscholar.org/graph/v1/paper";
+    const SS_FIELDS = "fields=title,citationCount,influentialCitationCount";
+
     let scrapeURL: string;
     if (paperEntity.doi !== "") {
-      scrapeURL = `https://api.paperlib.app/metadata/citationcount?doi=${paperEntity.doi}`;
+      scrapeURL = `${SS_BASE}/DOI:${paperEntity.doi}?${SS_FIELDS}`;
     } else if (paperEntity.arxiv !== "") {
-      scrapeURL = `https://api.paperlib.app/metadata/citationcount?arxiv=${
-        paperEntity.arxiv.toLowerCase().replace("arxiv:", "").split("v")[0]
-      }`;
+      const arxivId = paperEntity.arxiv.toLowerCase().replace("arxiv:", "").split("v")[0];
+      scrapeURL = `${SS_BASE}/ARXIV:${arxivId}?${SS_FIELDS}`;
     } else {
-      scrapeURL = `https://api.paperlib.app/metadata/citationcount?title=${stringUtils.formatString(
-        {
-          str: paperEntity.title,
-          whiteSymbol: true,
-        }
-      )}`;
+      const query = stringUtils.formatString({
+        str: paperEntity.title,
+        whiteSymbol: true,
+      });
+      scrapeURL = `${SS_BASE}/search?query=${query}&${SS_FIELDS}&limit=5`;
     }
 
     try {


### PR DESCRIPTION
## Summary

- `api.paperlib.app/metadata/citationcount` is currently returning 502 Bad Gateway, making the extension unable to fetch citation counts for any paper
- Replace the middleware with direct calls to the Semantic Scholar Graph API (`https://api.semanticscholar.org/graph/v1/paper`), which provides the same `citationCount` and `influentialCitationCount` fields
- Lookup priority remains the same: DOI → arXiv ID → title

## Changes

- DOI lookup: `GET /graph/v1/paper/DOI:{doi}?fields=title,citationCount,influentialCitationCount`
- arXiv lookup: `GET /graph/v1/paper/ARXIV:{arxivId}?fields=...`
- Title lookup: `GET /graph/v1/paper/search?query={title}&fields=...&limit=5`

Response parsing logic is unchanged — Semantic Scholar uses the same field names as the original middleware.

Fixes #2